### PR TITLE
sometime compare an empty string will fail with 'unary operator expected'

### DIFF
--- a/scripts/select.sh
+++ b/scripts/select.sh
@@ -43,7 +43,7 @@ do
             continue
         fi
         cer=$(curl https://$ip 2>&1 | grep -Po "'\S*'" |head -1|cut -d \' -f 2)
-        if [ $cer != $domain ]
+        if [ "$cer" != $domain ]
         then
             continue
         fi


### PR DESCRIPTION
:four_leaf_clover:
某些情况下会出现比较空串,`需要一元表达式`的错误。
