### PR TITLE
Added .gitattributes file to correct language tagging from GitHub.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+scripts/*.do linguist-vendored=true
+
+


### PR DESCRIPTION
This is the correction suggested by arfon to resolve [issue #91](https://github.com/txthinking/google-hosts/issues/91).  