### PR TITLE
docs: fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ This project provides some tools to help you find google IP.
 **`auto.sh` find CIDR from a DNS and run find.sh, select.sh, apply.sh**
 
     $ cd google-hosts/scripts
-    $ ./auto.sh DNS # DNS is like 8.8.8.8, but you should try DNS in diffrent countries.
+    $ ./auto.sh DNS # DNS is like 8.8.8.8, but you should try DNS in different countries.
 
-Explaination of output 
+Explanation of output 
 
 | IP  | LOSS        | TIME      | SSL        |
 | --- | ----------- | --------- | ---------- |


### PR DESCRIPTION
## Summary

Fixed two typos in `README.md`:

1. **`diffrent` → `different`** — in the `auto.sh` usage description
2. **`Explaination` → `Explanation`** — in the output table section header

These are straightforward spelling corrections that improve the readability of the documentation.